### PR TITLE
Update readme file: invasion orbs ID grouped together + typo fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,16 +92,13 @@ Specify folder location + filenames to use, and the alternate path will be used 
 
 * Fix for the halberd instant running attack glitch in mud and pvp
 
-* New item, "Searching Eye Orb" (id 104, available from the Undead Merchant), that searches all multiplayer areas while trying to invade  
-This allows you to invade any area across the entire game via 1 single use. It will continually search all areas rapidly, until cancelled or invasion found
-
-* New item, "Unbound Eye Orb" (id 105, available from the Undead Merchant), that does PTDE style red eye invasions: searching infinitely upwards in Soul Level.  
-This means, as a SL 100 character, you can invade anyone from SL 90 to SL 713.  
-This doesn't also enable infinite upwards weapon level searching, however.  
-
-* New item, "Twin Eye Orb" (id 109, available from the Undead Merchant), that does both of the above orbs' functions, combined.  
-
-* Versions of the above eye orbs, for Darkmoons.  
+* New items added:
+  * "__Searching Red Eye Orb__" (id 104, available from the Undead Merchant), that searches all multiplayer areas while trying to invade. This allows you to invade any area across the entire game via 1 single use. It will continually search all areas rapidly, until cancelled or invasion found.
+  * "__Unbound Red Eye Orb__" (id 105, available from the Undead Merchant), that does PTDE-style red eye invasions: searching infinitely upwards in Soul Level. This means, as a SL 100 character, you can invade anyone from SL 90 to SL 713. This doesn't also enable infinite upwards weapon level searching, however.
+  * "__Twin Red Eye Orb__" (id 107, available from the Undead Merchant), that does both of the above orbs' functions, combined.
+  * "__Searching Blue Eye Orb__" (id 150, available from the Undead Merchant), a variant of the "Searching Red Eye Orb" used to look for for blue (Darkmoon Covenant) invasions across all areas.
+  * "__Unbound Blue Eye Orb__" (id 151, available from the Undead Merchant), a variant of the "Unbound Red Eye Orb" used to look for blue (Darkmoon Covenant) invasions while searching infinitely upwards in Soul Level.
+  * "__Twin Blue Eye Orb__" (id 152, available from the Undead Merchant), a variant of the "Unbound Red Eye Orb" that does both of the above orbs' functions, combined.
 
 * System for selecting what areas you want to try invading with the above eye orbs.  
 Edit the included searchlist.txt with what areas to search for, and the orbs will only look in those areas.  
@@ -109,7 +106,7 @@ You can also edit the file while the game is running, and reloading your save wi
 
 * Basic update check system
 
-* Compatable with [Painted Worlds](https://www.nexusmods.com/darksoulsremastered/mods/527)
+* Compatible with [Painted Worlds](https://www.nexusmods.com/darksoulsremastered/mods/527)
 
 ### Overhaul
 


### PR DESCRIPTION
This PR provides a few small changes to the readme file: 

- The new Red Eye Orb items are now properly named like their in-game counterparts (they were lacking the "Red" monicker before).
- The ID and descriptions for all the newly-added invasion orbs are now grouped together.
- Fixed the reported ID for the Twin Red Eye Orb (it was indicated as 109, which is actually the ID for the Eye of Death).
- Fixed a minor typo.